### PR TITLE
MG-33 - Gatsby SEO and Head Tags26:20

### DIFF
--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -8,8 +8,10 @@ export default {
     title: 'Slicks Slices',
     siteUrl: 'https://gatsby.pizza',
     description: 'The Best Pizza place in Longland!',
+    twitter: `@slicksSlices`,
   },
   plugins: [
+    'gatsby-plugin-react-helmet',
     'gatsby-plugin-styled-components',
     {
       // this is the name of the plugin

--- a/gatsby/src/components/SEO.js
+++ b/gatsby/src/components/SEO.js
@@ -1,0 +1,46 @@
+import { graphql, useStaticQuery } from 'gatsby';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+export default function SEO({ children, location, description, title, image }) {
+  const { site } = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          title
+          description
+          twitter
+        }
+      }
+    }
+  `);
+
+  return (
+    <Helmet titleTemplate={`%s - ${site.siteMetadata.title}`}>
+      <html lang="en" />
+      <title>{title}</title>
+      {/* Fav Icons */}
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link rel="alternate icon" href="/favicon.ico" />
+      {/* Meta Tags */}
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta httpEquiv="Content-Type" content="text/html;charset=UTF-8" />
+      <meta name="description" content={site.siteMetadata.description} />
+      {/* Open Graph */}
+      <meta property="og:title" content={title} key="ogtitle" />
+      <meta
+        property="og:description"
+        content={site.siteMetadata.description}
+        key="ogdesc"
+      />
+      <meta
+        property="og:site_name"
+        content={site.siteMetadata.title}
+        key="ogsitename"
+      />
+      {location && <meta property="og:url" content={location.href} />}
+      <meta property="og:image" content={image || '/logo.svg'} />
+      {children}
+    </Helmet>
+  );
+}

--- a/gatsby/src/pages/beers.js
+++ b/gatsby/src/pages/beers.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import BeerList from '../components/BeerList';
+import SEO from '../components/SEO';
 
 export default function BeersPage({ data }) {
   console.log(data);
   const beers = data.beers.nodes;
   return (
     <>
+      <SEO title={`Our Beer List We have ${beers.length} options`} />
       <h2 className="center">We have {beers.length}!!! Dine in Only</h2>
       <BeerList beers={beers} />
     </>

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import SEO from '../components/SEO';
 
 export default function HomePage() {
   return (
     <>
+      <SEO />
       <p>Hey home page</p>
     </>
   );

--- a/gatsby/src/pages/orders.js
+++ b/gatsby/src/pages/orders.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import SEO from '../components/SEO';
 
 export default function OrdersPage() {
   return (
     <>
+      <SEO title="Orders My Pizza Page" />
       <p>Orders page</p>
     </>
   );

--- a/gatsby/src/pages/pizzas.js
+++ b/gatsby/src/pages/pizzas.js
@@ -2,11 +2,19 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import PizzaList from '../components/PizzaList';
 import ToppingsFilter from '../components/ToppingFilter';
+import SEO from '../components/SEO';
 
 export default function PizzasPage({ data, pageContext }) {
   const pizzas = data.pizzas.nodes;
   return (
     <>
+      <SEO
+        title={
+          pageContext.topping
+            ? `Pizzas with ${pageContext.topping}`
+            : `All Pizzas`
+        }
+      />
       <ToppingsFilter activeTopping={pageContext.topping} />
       <PizzaList pizzas={pizzas} />
       <aside>Graphql name your graphql query with name: query</aside>

--- a/gatsby/src/pages/slicemasters.js
+++ b/gatsby/src/pages/slicemasters.js
@@ -2,11 +2,13 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Pagination from '../components/pagination';
 import SliceMasterList from '../components/SliceMasters';
+import SEO from '../components/SEO';
 
 export default function SlicemastersPage({ data, pageContext }) {
   const slicemasters = data.slicemasters.nodes;
   return (
     <>
+      <SEO title={`Slicemasters -  Page ${pageContext.currentPage || 1}`} />
       <Pagination
         pageSize={parseInt(process.env.GATSBY_PAGE_SIZE)}
         totalCount={data.slicemasters.totalCount}

--- a/gatsby/src/templates/Pizza.js
+++ b/gatsby/src/templates/Pizza.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import styled from 'styled-components';
+import SEO from '../components/SEO';
 
 const PizzaGrid = styled.div`
   display: grid;
@@ -13,17 +14,20 @@ export default function SinglePizzaPage({ data }) {
   const { pizza } = data;
   // Destructure 2 levels down { data: { pizza } }
   return (
-    <PizzaGrid>
-      <Img fluid={pizza.image.asset.fluid} alt={pizza.name} />
-      <div>
-        <h2 className="mark">{pizza.name}</h2>
-        <ul>
-          {pizza.toppings.map((topping) => (
-            <li key={topping.id}>{topping.name}</li>
-          ))}
-        </ul>
-      </div>
-    </PizzaGrid>
+    <>
+      <SEO title={pizza.name} image={pizza.image?.asset?.fluid?.src} />
+      <PizzaGrid>
+        <Img fluid={pizza.image.asset.fluid} alt={pizza.name} />
+        <div>
+          <h2 className="mark">{pizza.name}</h2>
+          <ul>
+            {pizza.toppings.map((topping) => (
+              <li key={topping.id}>{topping.name}</li>
+            ))}
+          </ul>
+        </div>
+      </PizzaGrid>
+    </>
   );
 }
 

--- a/gatsby/src/templates/slicemaster.js
+++ b/gatsby/src/templates/slicemaster.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import styled from 'styled-components';
+import SEO from '../components/SEO';
 
 const SlicemasterStyles = styled.div`
   a {
@@ -24,6 +25,10 @@ export default function SliceMasterPage({ data: { slicemaster } }) {
 
   return (
     <SlicemasterStyles>
+      <SEO
+        title={slicemaster.name}
+        image={slicemaster.image?.asset?.fluid?.src}
+      />
       <Img fluid={slicemaster.image.asset.fluid} alt={slicemaster.name} />
       <h3>
         <span className="mark">{slicemaster.name}</span>

--- a/master-gatsby.code-workspace
+++ b/master-gatsby.code-workspace
@@ -10,6 +10,9 @@
         "Slicemaster",
         "apos",
         "hotspot",
+        "ogdesc",
+        "ogsitename",
+        "ogtitle",
         "slicemasters",
         "slicematers",
         "subgrid"

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ Based on a Premium JavaScript + CSS Training Course from Wes Bos. You can grab t
 1. Gatsby by default uses `module.exports = {` commonJS syntax node typically in the gatsby documentation and we want to use ES6 modules `export default {`. So that we can use es modules this project we use a package called esm. - to enable within the `package.json` we can add `NODE_OPTIONS="-r esm"` in front of `gatsby build`. The cross-env package is there for windows users.
 1. Page Queries (ie Dynamic) / Static Queries - Query outside of a page - ie ina function queries that do not take variables (gatsby limitation)
 1. To expose environments variable to the front end of your gatsby build they need to be prefixed with `GATSBY_`
+1. Nested chaining example to check for Items - `{pizza.image?.asset?.fluid?.src}` example in `gatsby/src/templates/Pizza.js`
 
 ## Running the Project
 


### PR DESCRIPTION
gatsby/gatsby-config.js
- Added Twitter Data
- Included React-Helmet Plugin for Gatsby

(NEW) -gatsby/src/components/SEO.js
- New Component using React-Helmet to add items to Head
- React Helmet updates show with data-react-helmet attributes

(Updated) Added the SEO Component and Data / Logic for Props to
 -  gatsby/src/pages/beers.js
 -  gatsby/src/pages/index.js
 -  gatsby/src/pages/orders.js
 -  gatsby/src/pages/pizzas.js
 -  gatsby/src/pages/slicemasters.js
 -  gatsby/src/templates/Pizza.js
 -  gatsby/src/templates/slicemaster.js

(Updated)  master-gatsby.code-workspace
- Addtional words added to dictionary

(Updated) readme.md
- Notes added on optional chaining