### PR TITLE
MG-37 - Calculating Order Total

### DIFF
--- a/gatsby/src/pages/orders.js
+++ b/gatsby/src/pages/orders.js
@@ -9,6 +9,7 @@ import OrderStyles from '../styles/OrderStyles';
 import MenuStyles from '../styles/MenuStyles';
 import usePizza from '../utils/usePizza';
 import PizzaOrder from '../components/PizzaOrder';
+import calculateOrderTotal from '../utils/calculateOrderTotal';
 
 export default function OrdersPage({ data }) {
   const pizzas = data.pizzas.nodes;
@@ -47,8 +48,9 @@ export default function OrdersPage({ data }) {
             />
           </label>
         </fieldset>
+
         <fieldset className="menu">
-          <legend>Menu Info</legend>
+          <legend>Menu</legend>
           {pizzas.map((pizza) => (
             <MenuStyles key={pizza.id}>
               <Img
@@ -80,6 +82,10 @@ export default function OrdersPage({ data }) {
             pizzas={pizzas}
             removeFromOrder={removeFromOrder}
           />
+        </fieldset>
+        <fieldset>
+          <h5>Your Total is {calculateOrderTotal(order, pizzas)}</h5>
+          <button type="submit">Order Ahead</button>
         </fieldset>
       </OrderStyles>
     </>

--- a/gatsby/src/utils/calculateOrderTotal.js
+++ b/gatsby/src/utils/calculateOrderTotal.js
@@ -1,0 +1,13 @@
+import formatMoney from './formatMoney';
+import calculatePizzaPrice from './calculatePizzaPrice';
+
+export default function calculateOrderTotal(order, pizzas) {
+  let orderTotal = 0;
+  order.map((singleOrder) => {
+    const pizza = pizzas.find((p) => singleOrder.id === p.id);
+
+    return (orderTotal += calculatePizzaPrice(pizza.price, singleOrder.size));
+  });
+
+  return formatMoney(orderTotal);
+}

--- a/gatsby/src/utils/calculateOrderTotalReduce.js
+++ b/gatsby/src/utils/calculateOrderTotalReduce.js
@@ -1,0 +1,12 @@
+import formatMoney from './formatMoney';
+import calculatePizzaPrice from './calculatePizzaPrice';
+
+export default function calculateOrderTotal(order, pizzas) {
+  const orderTotal = order.reduce((runningTotal, singleOrder) => {
+    const pizza = pizzas.find(
+      (singlePizza) => singlePizza.id === singleOrder.id
+    );
+    return runningTotal + calculatePizzaPrice(pizza.price, singleOrder.size);
+  }, 0);
+  return formatMoney(orderTotal);
+}


### PR DESCRIPTION
(updated) gatsby/src/pages/orders.js
- Added Order Total Fieldset
- Included calculateOrderTotal utility

- Calculate Order Total - 2 versions Map & Reduce
(new) gatsby/src/utils/calculateOrderTotal.js
- this is my version using Map
(new) gatsby/src/utils/calculateOrderTotalReduce.js
- This is the version outline by Wes
- Both versions elevate the formatMoney into the CalcTotal utility unlike Wes's that have this in the order.js