### PR TITLE
MG-38 - Moving our Order State to React Context with a custom Provider

### DIFF
--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import Layout from './src/components/Layout';
+import { OrderProvider } from './src/components/OrderContext';
 
 export function wrapPageElement({ element, props }) {
   return <Layout {...props}>{element}</Layout>;
+}
+
+export function wrapRootElement({ element }) {
+  return <OrderProvider>{element}</OrderProvider>;
 }

--- a/gatsby/gatsby-ssr.js
+++ b/gatsby/gatsby-ssr.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import Layout from './src/components/Layout';
+import { OrderProvider } from './src/components/OrderContext';
 
 export function wrapPageElement({ element, props }) {
   return <Layout {...props}>{element}</Layout>;
+}
+
+export function wrapRootElement({ element }) {
+  return <OrderProvider>{element}</OrderProvider>;
 }

--- a/gatsby/src/components/OrderContext.js
+++ b/gatsby/src/components/OrderContext.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+/* MG-38 - Moving our Order State to React Context with a custom Provider
+  Without react context when we navigate away from the Order page we loose the order,
+  This is because Gatsby will mount and unmount and remount it - so state is lost
+  To maintain state across pages - you have to put at the highest level.
+  - we will need to use the wrap root element hook in Gatsby
+  - we will need to move the state from Order.js and move into Context
+  - Context allows us to store data and functionality at a high level and access a lower level with out passing props
+*/
+// create a order context
+const OrderContext = React.createContext();
+
+// create a provider - this is a component that live at a higheer level and we inject around our route.
+export function OrderProvider({ children }) {
+  // we need to stick state here (same as our usePizza hook)
+  const [order, setOrder] = useState([]);
+
+  // Return OrderContext.Provider with the Children
+  // Make sure pass the value prop to the provider
+  return (
+    <OrderContext.Provider value={[order, setOrder]}>
+      {children}
+    </OrderContext.Provider>
+  );
+}
+
+export default OrderContext;

--- a/gatsby/src/utils/usePizza.js
+++ b/gatsby/src/utils/usePizza.js
@@ -1,8 +1,15 @@
-import { useState } from 'react';
+import { useContext } from 'react';
+import OrderContext from '../components/OrderContext';
 
 export default function usePizza({ pizzas, inputs }) {
   // 1, Create Ste to hold our order
-  const [order, setOrder] = useState([]);
+
+  // MG-38 - this line is not required as useState moved up to the Provider - OrderContext.js
+  // const [order, setOrder] = useState([]);
+
+  // MG-38 - Now we access state and update function setOrder via context
+  const [order, setOrder] = useContext(OrderContext);
+
   // 2. Make a function to add things to order
   function addToOrder(orderedPizza) {
     setOrder([...order, orderedPizza]);


### PR DESCRIPTION
(new) - gatsby/src/components/OrderContext.js
- Created OrderContext Provider from React.createContext to hold state
- passed the values down to the children

(updated) gatsby/gatsby-browser.js
(updated) gatsby/gatsby-ssr.js
- Update the Gatsby Application to be wrapped by our custom provider
- need to include for both browser and ssr rendering

(updated) gatsby/src/utils/usePizza.js
- custom hook changed to use our custom context
- remove of useState in import
- Update where state is initialisd from in the hook - see line 8 & 11