### PR TITLE
MG44 - Creating a one-off Store Settings Page 

### DIFF
--- a/sanity/sanity.json
+++ b/sanity/sanity.json
@@ -17,15 +17,17 @@
   ],
   "env": {
     "development": {
-      "plugins": [
-        "@sanity/vision"
-      ]
+      "plugins": ["@sanity/vision"]
     }
   },
   "parts": [
     {
       "name": "part:@sanity/base/schema",
       "path": "./schemas/schema"
+    },
+    {
+      "name": "part:@sanity/desk-tool/structure",
+      "path": "./sidebar"
     }
   ]
 }

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -7,11 +7,12 @@ import schemaTypes from 'all:part:@sanity/base/schema-type';
 import pizza from './pizza';
 import topping from './topping';
 import person from './person';
+import storeSettings from './storeSettings';
 
 export default createSchema({
   // We name our schema
   name: 'default',
   // Then proceed to concatenate our document type
   // to the ones provided by any plugins that are installed
-  types: schemaTypes.concat([pizza, topping, person]),
+  types: schemaTypes.concat([storeSettings, pizza, topping, person]),
 });

--- a/sanity/schemas/storeSettings.js
+++ b/sanity/schemas/storeSettings.js
@@ -1,0 +1,30 @@
+import { MdStore as icon } from 'react-icons/md';
+
+export default {
+  // Computer Name
+  name: 'storeSettings',
+  // Display name
+  title: 'Settings',
+  type: 'document',
+  icon,
+  fields: [
+    {
+      name: 'name',
+      title: 'Store Name',
+      type: 'string',
+      description: 'Name of the Store',
+    },
+    {
+      name: 'slicemaster',
+      title: 'Slicemasters Currently Slicing',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'person' }] }],
+    },
+    {
+      name: 'hotSlices',
+      title: 'Hot Slices in the case',
+      type: 'array',
+      of: [{ type: 'reference', to: [{ type: 'pizza' }] }],
+    },
+  ],
+};

--- a/sanity/sidebar.js
+++ b/sanity/sidebar.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import S from '@sanity/desk-tool/structure-builder';
+
+// build a customer sidebar
+
+export default function Sidebar() {
+  return S.list()
+    .title(`Slick's Slices`)
+    .items([
+      // create a new sub item
+      S.listItem()
+        .title('Home Page')
+        .icon(() => <strong>🔥</strong>)
+        .child(
+          S.editor()
+            .schemaType('storeSettings')
+            // make a new document ID, so we dont have a random string of numbers
+            .documentId('downtown')
+        ),
+      // add in the rest of our document items
+      ...S.documentTypeListItems().filter(
+        (item) => item.getId() !== 'storeSettings'
+      ),
+    ]);
+}


### PR DESCRIPTION
(feat)  sanity/sanity.json
- Added in Sidebar support for custom sidebar to manage homepage Store Settings

(feat) sanity/schemas/schema.js
- Include data type for Store Settings

(new) sanity/schemas/storeSettings.js
- New Data Type for use on the Homepage (could be extended for multiple stores)
- Data is a link to an array of arrays

(new)  sanity/sidebar.js
- Define custom sidebar (sanity specific)
- Use sanity functions to define and build custom sidebar