### PR TITLE
MG-45 - Custom Hook for Client Side Data Fetching

### DIFF
--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -1,11 +1,33 @@
 import React from 'react';
 import SEO from '../components/SEO';
+import useLatestData from '../utils/useLatestData';
 
-export default function HomePage() {
+function CurrentlySlicing() {
   return (
-    <>
-      <SEO />
-      <p>Hey home page</p>
-    </>
+    <div>
+      <h3>Currently Slicing</h3>Custom Component
+    </div>
+  );
+}
+function HotSlices() {
+  return (
+    <div>
+      <h3>Pizzas by the Slice</h3>Custom Component
+    </div>
+  );
+}
+export default function HomePage() {
+  const { sliceMasters, hotSlices } = useLatestData();
+
+  return (
+    <div className="center">
+      <SEO title="Sick's Slices - The Best Pizzas" />
+      <h2>The Best Pizza Downtown!</h2>
+      <p>Open 11am to 11pm Every Single Day</p>
+      <div>
+        <CurrentlySlicing sliceMasters={sliceMasters} />
+        <HotSlices hotSlices={hotSlices} />
+      </div>
+    </div>
   );
 }

--- a/gatsby/src/utils/useLatestData.js
+++ b/gatsby/src/utils/useLatestData.js
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+export default function useLatestData() {
+  // hot slices
+  const [hotSlices, setHotSlices] = useState();
+  // slicemaster
+  const [sliceMasters, setSliceMasters] = useState();
+
+  // Use a side effect to fetch the data from the graphql endpoint
+  useEffect(() => {
+    // When the component loads, fetch the data
+    fetch(process.env.GATSBY_GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `
+        query {
+          StoreSettings(id: "downtown"){
+            slicemaster{
+              name
+            }
+            hotSlices{
+              name
+            }
+          }
+          
+        }
+        
+        `,
+      }),
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        // TODO: check for errors
+        // TODO: set the data to state
+        setHotSlices(res.data.StoreSettings.hotSlices);
+        setSliceMasters(res.data.StoreSettings.slicemaster);
+      });
+  }, []);
+
+  return {
+    hotSlices,
+    sliceMasters,
+  };
+}


### PR DESCRIPTION
Grab the Homepage data via a custom hook, directly from Sanity as a live call
This ensure's the latest data is available.

(feat) gatsby/src/pages/index.js
- New custom components for Currently Slicing and HotSlices
- call to new custom hook useLatestData - destructure sliceMasters / hotSlices
- Update SEO component
- Add padding of the page content
- Includee new components and pass data via props

(new)  gatsby/src/utils/useLatestData.js
- Custom Hook, will useEffect & pull data direct from Sanity and update state
- Define new state objects for Slicers and Pizza Slices
- useEffect will fetch data from Sanity, based on query based in the body
- Once result is received add data to state
- return state from custom hook