### PR TITLE
MG-46 Creating a Skeleton Screen while Loading Items

### DIFF
--- a/gatsby/src/components/LoadingGrid.js
+++ b/gatsby/src/components/LoadingGrid.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ItemsGrid, ItemStyle } from '../styles/Grids';
+
+function LoadingGrid({ count }) {
+  return (
+    <ItemsGrid>
+      {Array.from({ length: count }, (_, i) => (
+        <ItemStyle key={Math.random() + i}>
+          <p>
+            <span className="mark">Loading...</span>
+          </p>
+          {/* Image Generated from PNG-PIXEL.com */}
+          <img
+            src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAECAQAAADsOj3LAAAADklEQVR42mNkgANGQkwAAJoABWH6GPAAAAAASUVORK5CYII="
+            alt="loading"
+            className="loading"
+            srcSet=""
+            width="500"
+            height="400"
+          />
+        </ItemStyle>
+      ))}
+    </ItemsGrid>
+  );
+}
+
+export default LoadingGrid;

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -1,18 +1,24 @@
 import React from 'react';
+import LoadingGrid from '../components/LoadingGrid';
 import SEO from '../components/SEO';
+import { HomePageGrid } from '../styles/Grids';
 import useLatestData from '../utils/useLatestData';
 
-function CurrentlySlicing() {
+function CurrentlySlicing({ sliceMasters }) {
   return (
     <div>
-      <h3>Currently Slicing</h3>Custom Component
+      {!sliceMasters && <LoadingGrid count={4} />}
+      {sliceMasters && !sliceMasters?.length && (
+        <p>No one is slicing at present</p>
+      )}
     </div>
   );
 }
-function HotSlices() {
+function HotSlices({ hotSlices }) {
   return (
     <div>
-      <h3>Pizzas by the Slice</h3>Custom Component
+      {!hotSlices && <LoadingGrid count={4} />}
+      {hotSlices && !hotSlices?.length && <p>No Slices available</p>}
     </div>
   );
 }
@@ -24,10 +30,10 @@ export default function HomePage() {
       <SEO title="Sick's Slices - The Best Pizzas" />
       <h2>The Best Pizza Downtown!</h2>
       <p>Open 11am to 11pm Every Single Day</p>
-      <div>
+      <HomePageGrid>
         <CurrentlySlicing sliceMasters={sliceMasters} />
         <HotSlices hotSlices={hotSlices} />
-      </div>
+      </HomePageGrid>
     </div>
   );
 }

--- a/gatsby/src/styles/Grids.js
+++ b/gatsby/src/styles/Grids.js
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+export const HomePageGrid = styled.div`
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(2, minmax(auto, 1fr));
+`;
+
+export const ItemsGrid = styled.div`
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+`;
+
+// single grid item (for home page)
+export const ItemStyle = styled.div`
+  text-align: center;
+  position: relative;
+  img {
+    height: auto;
+    font-size: 0;
+  }
+  p {
+    transform: rotate(-2deg) translateY(-50%);
+    position: absolute;
+    width: 100%;
+    left: 0;
+  }
+  .mark {
+    display: inline;
+  }
+  @keyframes shine {
+    from {
+      background-position: 200%;
+    }
+    to {
+      background-position: -40px;
+    }
+  }
+  img.loading {
+    --shine: white;
+    --background: var(--grey);
+    background-image: linear-gradient(
+      90deg,
+      var(--background) 0px,
+      var(--shine) 40px,
+      var(--background) 80px
+    );
+    background-size: 500px;
+    animation: shine 1s infinite linear;
+  }
+`;


### PR DESCRIPTION
(new) ../gatsby/src/components/LoadingGrid.js
- New custom component for creating skeleton
- Takes no of items to provide holding space whilst content is loading
- Uses styled components fomr Grids.js

(feat)   ../gatsby/src/pages/index.js
- Layout Grid for SliceMasters and HotSlices
- Update components to receive slicemaster and hotslices props
- Check in components for values / loading state and display skeleton framework
- Hide framework if data returned
- Provide holidy message if not data returned

(new) ../gatsby/src/styles/Grids.js
- Homepage Grid setup
- Inner Grid style for homepae
- Custom grid styles via styled components
- animationin place for loading components