### PR TITLE
MG-47 - Displaying the Home Page Data

### DIFF
--- a/gatsby/src/components/ItemGrid.js
+++ b/gatsby/src/components/ItemGrid.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ItemsGrid, ItemStyle } from '../styles/Grids';
+
+function ItemGrid({ items }) {
+  return (
+    <ItemsGrid>
+      {items.map((item, index) => (
+        <ItemStyle>
+          <p>
+            <span className="mark">{item.name}</span>
+          </p>
+          <img
+            src={`${item.image.asset.url}?w=500&h=400&fit=crop`}
+            // src=""
+            alt={item.name}
+            width="500"
+            height="400"
+            style={{
+              background: `url(${item.image.asset.metadata.lqip})`,
+              backgroundSize: 'cover',
+            }}
+          />
+        </ItemStyle>
+      ))}
+    </ItemsGrid>
+  );
+}
+
+export default ItemGrid;

--- a/gatsby/src/components/Nav.js
+++ b/gatsby/src/components/Nav.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import Logo from './Logo';
 
 const NavStyles = styled.nav`
-  margin-bottom: 3rem;
   .logo {
     transform: translateY(-25%);
   }

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -1,24 +1,35 @@
 import React from 'react';
+import ItemGrid from '../components/ItemGrid';
 import LoadingGrid from '../components/LoadingGrid';
 import SEO from '../components/SEO';
-import { HomePageGrid } from '../styles/Grids';
+import { HomePageGrid, ItemsGrid } from '../styles/Grids';
 import useLatestData from '../utils/useLatestData';
 
 function CurrentlySlicing({ sliceMasters }) {
   return (
     <div>
+      <h2 className="center">
+        <span className="mark tilt">Slicemasters On</span>
+      </h2>
+      <p>Ready to slice you up!</p>
       {!sliceMasters && <LoadingGrid count={4} />}
       {sliceMasters && !sliceMasters?.length && (
         <p>No one is slicing at present</p>
       )}
+      {sliceMasters?.length && <ItemGrid items={sliceMasters} />}
     </div>
   );
 }
 function HotSlices({ hotSlices }) {
   return (
     <div>
+      <h2 className="center">
+        <span className="mark tilt">Hot Slices</span>
+      </h2>
+      <p>Ready to eat now!</p>
       {!hotSlices && <LoadingGrid count={4} />}
       {hotSlices && !hotSlices?.length && <p>No Slices available</p>}
+      {hotSlices?.length && <ItemGrid items={hotSlices} />}
     </div>
   );
 }

--- a/gatsby/src/styles/GlobalStyles.js
+++ b/gatsby/src/styles/GlobalStyles.js
@@ -67,11 +67,8 @@ const GlobalStyles = createGlobalStyle`
   img {
     max-width: 100%;
   }
-  .tilt {
-    transform: rotate(-2deg);
-    position: relative;
-    display: inline-block;
-  }
+
+  
   aside {
     display:none;
   }

--- a/gatsby/src/styles/Grids.js
+++ b/gatsby/src/styles/Grids.js
@@ -21,13 +21,13 @@ export const ItemStyle = styled.div`
     font-size: 0;
   }
   p {
-    transform: rotate(-2deg) translateY(-50%);
+    transform: rotate(-2deg) translateY(-140%);
     position: absolute;
     width: 100%;
     left: 0;
   }
   .mark {
-    display: inline;
+    display: inline-block;
   }
   @keyframes shine {
     from {

--- a/gatsby/src/styles/Typography.js
+++ b/gatsby/src/styles/Typography.js
@@ -38,6 +38,8 @@ const Typography = createGlobalStyle`
 
   .tilt {
     transform: rotate(-2deg);
+    position: relative;
+    display: inline-block;
   }
 `;
 

--- a/gatsby/src/utils/useLatestData.js
+++ b/gatsby/src/utils/useLatestData.js
@@ -1,11 +1,26 @@
 import { useState, useEffect } from 'react';
 
 export default function useLatestData() {
+  // Fake out VS Code for code formating
+  const gql = String.raw;
   // hot slices
   const [hotSlices, setHotSlices] = useState();
   // slicemaster
   const [sliceMasters, setSliceMasters] = useState();
 
+  const deets = `
+              name
+                slug {
+                  current
+                }
+              image {
+                asset {
+                  url
+                  metadata {
+                    lqip
+                  }
+                }
+              }`;
   // Use a side effect to fetch the data from the graphql endpoint
   useEffect(() => {
     // When the component loads, fetch the data
@@ -15,19 +30,19 @@ export default function useLatestData() {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        query: `
-        query {
-          StoreSettings(id: "downtown"){
-            slicemaster{
-              name
-            }
-            hotSlices{
-              name
+        query: gql`
+          query {
+            StoreSettings(id: "downtown") {
+              slicemaster {
+                
+                ${deets}
+              }
+              hotSlices {
+                
+                ${deets}
+              }
             }
           }
-          
-        }
-        
         `,
       }),
     })
@@ -37,6 +52,9 @@ export default function useLatestData() {
         // TODO: set the data to state
         setHotSlices(res.data.StoreSettings.hotSlices);
         setSliceMasters(res.data.StoreSettings.slicemaster);
+      })
+      .catch((err) => {
+        console.log(err);
       });
   }, []);
 


### PR DESCRIPTION
(new) ../gatsby/src/components/ItemGrid.js
- New Component to display Sanity Live Data Fields

(layout) ../gatsby/src/components/Nav.js
- removed bottom margin

(feat) ../gatsby/src/pages/index.js
- Add titles to Currently Slicing and HotSlices
- If data returned from useLatestData hook pass to ItemGrid

(feat) ../gatsby/src/utils/useLatestData.js
- Update graphql query for updated data
- fake format via String.raw for gql
- use string literal for repetion on graphql query

(layout)  ../gatsby/src/styles/GlobalStyles.js
(layout)  ../gatsby/src/styles/Grids.js
(layout)  ../gatsby/src/styles/Typography.js
- update styling